### PR TITLE
fix: use shield

### DIFF
--- a/async_property/cached.py
+++ b/async_property/cached.py
@@ -112,10 +112,10 @@ class AsyncCachedPropertyDescriptor:
                 value = await self._fget(instance)
                 self.__set__(instance, value)
                 return value
-        return load_value
+        return lambda: shield(load_value())
 
     def already_loaded(self, instance):
         return AwaitableProxy(self.get_cache_value(instance))
 
     def not_loaded(self, instance):
-        return AwaitableOnly(shield(self.get_loader(instance)))
+        return AwaitableOnly(self.get_loader(instance))


### PR DESCRIPTION
The code of a cached_property can run more than once in the following situation:

1: current_task awaits a long running method decorated with async_cached_property
2: second_task also awaits the same async_cached_property which has not finished loading, it ends up waiting at the asyncio.Lock
3: current_task gets cancelled for any reason
4: long running coroutine stops executing without completing, side effects might have already occurred
5: second_task is woken up at the asyncio.Lock and again starts the long running coroutine

By wrapping the loader with asyncio.shield, we can guarantee the wrapped function will only execute once and that it will not be interrupted even if the calling task is