### PR TITLE
fix: pop locks from instance state after cache value is loaded

### DIFF
--- a/async_property/cached.py
+++ b/async_property/cached.py
@@ -86,6 +86,9 @@ class AsyncCachedPropertyDescriptor:
         lock = self.get_instance_state(instance).lock
         return lock[self.field_name]
 
+    def pop_lock(self, instance):
+        self.get_instance_state(instance).lock.pop(self.field_name)
+
     def get_cache(self, instance):
         return self.get_instance_state(instance).cache
 
@@ -113,6 +116,7 @@ class AsyncCachedPropertyDescriptor:
                     return self.get_cache_value(instance)
                 value = await self._fget(instance)
                 self.__set__(instance, value)
+                self.pop_lock(instance)
                 return value
         return load_value
 


### PR DESCRIPTION
After the cache value is loaded, the asyncio.Lock is not used again. This PR pops it from the instance state after loading to keep resource consumption to a minimum.